### PR TITLE
Update for Segment 4.1

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,3 +1,5 @@
+platform :ios, '11.0'
+
 target 'Segment-Apptimize_Example' do
   pod 'Segment-Apptimize', :path => '../'
 

--- a/Segment-Apptimize.podspec
+++ b/Segment-Apptimize.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Segment-Apptimize"
-  s.version          = "0.3.2"
+  s.version          = "0.3.3"
   s.summary          = "Apptimize Integration for Segment's analytics-ios library."
 
   s.description      = <<-DESC
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Segment-Apptimize/Classes/**/*'
 
-  s.dependency 'Analytics', '~> 3'
-  s.dependency 'Apptimize', '~> 3'
+  s.dependency 'Analytics', '>= 3.0'
+  s.dependency 'Apptimize', '~> 3.0'
 end

--- a/Segment-Apptimize/Classes/SEGApptimizeIntegration.h
+++ b/Segment-Apptimize/Classes/SEGApptimizeIntegration.h
@@ -1,7 +1,12 @@
 #import <Foundation/Foundation.h>
+
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegration.h>
 #import <Analytics/SEGAnalytics.h>
-
+#else
+#import <Segment/SEGIntegration.h>
+#import <Segment/SEGAnalytics.h>
+#endif
 
 @interface SEGApptimizeIntegration : NSObject <SEGIntegration>
 

--- a/Segment-Apptimize/Classes/SEGApptimizeIntegration.m
+++ b/Segment-Apptimize/Classes/SEGApptimizeIntegration.m
@@ -52,34 +52,26 @@ static NSString *const VIEWED_TAG_FORMAT = @"Viewed %@ screen";
     if( enable ) {
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(experimentDidGetViewed:)
-                                                     name:ApptimizeTestRunNotification
+                                                     name:ApptimizeParticipatedInExperimentNotification
                                                    object:nil];
     }
 }
 
 - (void)experimentDidGetViewed:(NSNotification *)notification
 {
-    if (![notification.userInfo[ApptimizeTestFirstRunUserInfoKey] boolValue]) {
+    if (![notification.userInfo[ApptimizeFirstParticipationKey] boolValue]) {
         return;
     }
 
-    // Apptimize doesn't notify with IDs, so we iterate over all experiments to find the matching one.
-    NSString *name = notification.userInfo[ApptimizeTestNameUserInfoKey];
-    NSString *variant = notification.userInfo[ApptimizeVariantNameUserInfoKey];
-    [[_apptimizeClass testInfo] enumerateKeysAndObjectsUsingBlock:^(id key, id<ApptimizeTestInfo> experiment, BOOL *stop) {
-        BOOL match = [experiment.testName isEqualToString:name] && [experiment.enrolledVariantName isEqualToString:variant];
-        if (!match) {
-            return;
-        }
-        [self.analytics track:@"Experiment Viewed"
-                   properties:@{
-                       @"experimentId" : [experiment testID],
-                       @"experimentName" : [experiment testName],
-                       @"variationId" : [experiment enrolledVariantID],
-                       @"variationName" : [experiment enrolledVariantName]
-                   }];
-        *stop = YES;
-    }];
+    id<ApptimizeTestInfo> testInfo = notification.userInfo[ApptimizeTestInfoKey];
+
+    [self.analytics track:@"Experiment Viewed"
+               properties:@{
+                   @"experimentId" : [testInfo testID],
+                   @"experimentName" : [testInfo testName],
+                   @"variationId" : [testInfo enrolledVariantID],
+                   @"variationName" : [testInfo enrolledVariantName]
+               }];
 }
 
 - (void)identify:(SEGIdentifyPayload *)payload

--- a/Segment-Apptimize/Classes/SEGApptimizeIntegrationFactory.h
+++ b/Segment-Apptimize/Classes/SEGApptimizeIntegrationFactory.h
@@ -1,6 +1,10 @@
 #import <Foundation/Foundation.h>
-#import <Analytics/SEGIntegrationFactory.h>
 
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
+#import <Analytics/SEGIntegrationFactory.h>
+#else
+#import <Segment/SEGIntegrationFactory.h>
+#endif
 
 @interface SEGApptimizeIntegrationFactory : NSObject <SEGIntegrationFactory>
 


### PR DESCRIPTION
Set Analytics dependency to >= 3.0.
Apptimize dependency modified to ~> 3.0.
Support including including the Analytics headers from either Analytics or Segment package.
Update Apptimize integration to stop using the deprecated `ApptimizeParticipatedInExperimentNotification` which would generate a warning.